### PR TITLE
Use input file redirection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,4 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 )
 
-require golang.org/x/sys v0.0.0-20210331175145-43e1dd70ce54 // indirect
+require golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/creasty/defaults v1.5.2/go.mod h1:FPZ+Y0WNrbqOVw+c6av63eyHUAl6pMHZwqL
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 golang.org/x/sys v0.0.0-20210331175145-43e1dd70ce54 h1:rF3Ohx8DRyl8h2zw9qojyLHLhrJpEMgyPOImREEryf0=
 golang.org/x/sys v0.0.0-20210331175145-43e1dd70ce54/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/pantest.go
+++ b/pantest.go
@@ -4,7 +4,6 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -184,14 +183,14 @@ func testExec(exe Exec, tests []TestCase, baseEvent Event, events chan<- Event) 
 func runTest(exe Exec, test TestCase, baseEvent Event, events chan<- Event) {
 	events <- baseEvent.Status(STARTING)
 
-	inputBytes, err := ioutil.ReadFile(test.inputFilename)
+	inputBytes, err := os.ReadFile(test.inputFilename)
 	if err != nil {
 		events <- baseEvent.Status(FAILED).Msg(fmt.Sprintf("failed to read input: %v", err))
 		return
 	}
 	input := string(inputBytes)
 
-	refBytes, err := ioutil.ReadFile(test.refFilename)
+	refBytes, err := os.ReadFile(test.refFilename)
 	if err != nil {
 		events <- baseEvent.Status(FAILED).Msg(fmt.Sprintf("failed to read ref: %v", err))
 		return


### PR DESCRIPTION
This PR:
- uses input file redirection when testing executables (instead of reading the file in memory)
- updates some deprecated functions and dependency versions