### PR TITLE
Add the `same` subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,24 @@ git clone https://github.com/pandrei7/pantest
 cd pantest
 go mod tidy
 ```
+
 ## Usage
 
 First create a configuration file using `go run . init` and
 [customize](#configuration) it to your needs.
 
-Then execute `go run .` to run the tests.
+Then execute `go run . run` to run the tests.
+
+To check that two programs have the same output on random tests run
+`go run . same --help`.
 
 ## Configuration
 
 The input and reference files should have `.in` and `.ref` extensions,
 respectively. Ideally, they should also contain a number in the name.
+
+For similarity checking, you should provide a command to generate a random test
+case (written to standard out) and a directory where these tests will be saved.
 
 Make sure all sources **use standard IO to read and write**, not file IO.
 

--- a/cli.go
+++ b/cli.go
@@ -5,7 +5,7 @@ type ParamsInit struct {
 }
 
 type ParamsRun struct {
-	ConfigFile string `short:"f" type:"path" default:"pantest.yml" help:"Choose the configuration file."`
+	ConfigFile string `short:"f" type:"existingfile" default:"pantest.yml" help:"Choose the configuration file."`
 }
 
 type Cli struct {

--- a/cli.go
+++ b/cli.go
@@ -8,9 +8,17 @@ type ParamsRun struct {
 	ConfigFile string `short:"f" type:"existingfile" default:"pantest.yml" help:"Choose the configuration file."`
 }
 
+type ParamsSame struct {
+	ParamsRun
+	Rounds int    `arg:"" help:"Number of tests to run."`
+	Exec1  string `arg:"" help:"Name of the first executable to test."`
+	Exec2  string `arg:"" help:"Name of the second executable to test."`
+}
+
 type Cli struct {
 	Init ParamsInit `cmd:"" help:"Create a new configuration file."`
 	Run  ParamsRun  `cmd:"" help:"Run the tests."`
+	Same ParamsSame `cmd:"" help:"Check the functional similarity of two programs with random tests."`
 }
 
 func (p *ParamsInit) Run() error {
@@ -19,5 +27,10 @@ func (p *ParamsInit) Run() error {
 
 func (p *ParamsRun) Run() error {
 	runCli(p.ConfigFile)
+	return nil
+}
+
+func (p *ParamsSame) Run() error {
+	runSame(p.ConfigFile, p.Rounds, p.Exec1, p.Exec2)
 	return nil
 }

--- a/config-template.yml
+++ b/config-template.yml
@@ -1,10 +1,17 @@
 # Max number of working goroutines at one time.
 maxWorkers: 8
 
+# Parameters for the `run` command.
 # Input files should have the `.in` extension.
 # Ref files should have these same names, but with the `.ref` extension.
 inputDir: your-path/input
 refDir: your-path/ref
+
+# Parameters for the `same` command.
+# The command which generates a random test (writes to stdout).
+testGenCmd: ['python3', 'your-script']
+# The directory where random tests are generated.
+testGenDir: 'your-path'
 
 # All executables must read from stdin and write to stdout.
 # Use the `ignore` key to avoid having to comment out an executable.

--- a/config.go
+++ b/config.go
@@ -9,10 +9,12 @@ import (
 )
 
 type Config struct {
-	MaxWorkers int    `yaml:"maxWorkers" default:"10"`
-	InputDir   string `yaml:"inputDir"`
-	RefDir     string `yaml:"refDir"`
-	Execs      []Exec `yaml:"execs"`
+	MaxWorkers int      `yaml:"maxWorkers" default:"10"`
+	InputDir   string   `yaml:"inputDir"`
+	RefDir     string   `yaml:"refDir"`
+	TestGenCmd []string `yaml:"testGenCmd"`
+	TestGenDir string   `yaml:"testGenDir"`
+	Execs      []Exec   `yaml:"execs"`
 }
 
 type Exec struct {

--- a/pantest.go
+++ b/pantest.go
@@ -110,7 +110,7 @@ func runChecks(config Config) {
 		tm.Println()
 		tm.Flush()
 		// goterm does not seem to handle big strings? Use fmt instead.
-		fmt.Print(summarizer.Summary())
+		fmt.Print(summarizer.Summary(true))
 
 		monitorDone <- struct{}{}
 	}()

--- a/pantest.go
+++ b/pantest.go
@@ -31,6 +31,9 @@ const (
 	WA
 	TLE
 	OK
+	GENERATING
+	SAME_OUT
+	MISMATCH
 )
 
 type Event struct {

--- a/same.go
+++ b/same.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path"
+	"strconv"
+	"sync"
+
+	tm "github.com/buger/goterm"
+)
+
+func runSame(configFilename string, rounds int, execName1, execName2 string) {
+	config, err := ParseConfig(configFilename)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	exec1, err := findExec(config.Execs, execName1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	exec2, err := findExec(config.Execs, execName2)
+	if err != nil {
+		log.Fatal(err)
+	}
+	config.Execs = []Exec{exec1, exec2}
+
+	runSameTests(config, rounds, exec1, exec2)
+}
+
+func findExec(execs []Exec, execName string) (Exec, error) {
+	var resultExec Exec
+	matches := 0
+
+	for _, exec := range execs {
+		if exec.Name == execName {
+			resultExec = exec
+			matches += 1
+		}
+	}
+
+	if matches > 1 {
+		return Exec{}, fmt.Errorf("multiple executables (%v) found for '%v'", matches, execName)
+	}
+	if matches < 1 {
+		return Exec{}, fmt.Errorf("executable '%v' not found", execName)
+	}
+	return resultExec, nil
+}
+
+func runSameTests(config Config, rounds int, exec1, exec2 Exec) {
+	if err := os.MkdirAll(config.TestGenDir, 0777); err != nil {
+		log.Fatal(fmt.Errorf("failed to create directory for inputs: %w", err))
+	}
+
+	maxWorkers := decideMaxWorkers(config)
+	displayStartupInfo(config, rounds, maxWorkers)
+
+	events := make(chan Event)
+	monitorDone := make(chan struct{}, 1)
+	go func() {
+		// Generate fictive tests for the UI. This should be fixed in the future.
+		fakeTestcases := make([]TestCase, rounds)
+		for i := 0; i < rounds; i += 1 {
+			fakeTestcases[i] = TestCase{name: fmt.Sprintf("%v", i)}
+		}
+
+		summarizer := NewSummarizer(config.Execs)
+		ui := NewUI(config.Execs, fakeTestcases)
+		ui.InitDisplay()
+		for event := range events {
+			summarizer.Ingest(event)
+			ui.Display(event)
+		}
+		tm.Println()
+		tm.Flush()
+		// goterm does not seem to handle big strings? Use fmt instead.
+		fmt.Print(summarizer.Summary())
+
+		monitorDone <- struct{}{}
+	}()
+
+	var wg sync.WaitGroup
+	limiter := make(chan struct{}, maxWorkers)
+	for i := 0; i < rounds; i += 1 {
+		wg.Add(1)
+		go func(index int) {
+			limiter <- struct{}{}
+			defer wg.Done()
+			runSameTest(index, config, exec1, exec2, Event{testIndex: index}, events)
+			<-limiter
+		}(i)
+	}
+	wg.Wait()
+	close(events)
+
+	<-monitorDone
+}
+
+func runSameTest(index int, config Config, exec1, exec2 Exec, baseEvent Event, events chan<- Event) {
+	events <- baseEvent.Exec(0).Status(GENERATING)
+	events <- baseEvent.Exec(1).Status(GENERATING)
+
+	inputFilename := path.Join(config.TestGenDir, strconv.Itoa(index))
+	if err := generateInput(config.TestGenCmd, inputFilename); err != nil {
+		msg := fmt.Sprintf("failed to generate input: %v", err)
+		events <- baseEvent.Exec(0).Status(FAILED).Msg(msg)
+		events <- baseEvent.Exec(1).Status(FAILED)
+		return
+	}
+
+	inputFile, err := os.Open(inputFilename)
+	if err != nil {
+		msg := fmt.Sprintf("failed to open input file: %v", err)
+		events <- baseEvent.Exec(0).Status(FAILED).Msg(msg)
+		events <- baseEvent.Exec(1).Status(FAILED)
+		return
+	}
+	defer inputFile.Close()
+
+	events <- baseEvent.Exec(0).Status(STARTING)
+	out1, err1 := runProgram(inputFile, exec1.Cmd, exec1.Timeout)
+	if err1 != nil {
+		events <- baseEvent.Exec(0).Status(determineStatus(err1))
+	}
+
+	// The first run "consumed" our file.
+	inputFile.Seek(0, io.SeekStart)
+
+	events <- baseEvent.Exec(1).Status(STARTING)
+	out2, err2 := runProgram(inputFile, exec2.Cmd, exec2.Timeout)
+	if err2 != nil {
+		events <- baseEvent.Exec(1).Status(determineStatus(err2))
+	}
+
+	if err1 != nil || err2 != nil {
+		if err1 == nil {
+			events <- baseEvent.Exec(0).Status(SAME_OUT)
+		}
+		if err2 == nil {
+			events <- baseEvent.Exec(1).Status(SAME_OUT)
+		}
+		return
+	}
+
+	if !compatibleOutputs(out1, out2) {
+		events <- baseEvent.Exec(0).Status(MISMATCH)
+		events <- baseEvent.Exec(1).Status(MISMATCH)
+		return
+	}
+
+	events <- baseEvent.Exec(0).Status(SAME_OUT)
+	events <- baseEvent.Exec(1).Status(SAME_OUT)
+
+	// Remove the input file, since it's not interesting anymore.
+	if err := os.Remove(inputFilename); err != nil {
+		msg := fmt.Sprintf("failed to remove %s: %v", inputFilename, err)
+		events <- baseEvent.Exec(0).Msg(msg)
+	}
+}
+
+func generateInput(cmdArgs []string, filename string) error {
+	file, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
+	cmd.Stdout = file
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	return cmd.Wait()
+}
+
+func determineStatus(err error) Status {
+	if err == nil {
+		return NONE
+	}
+	if isTimeout(err) {
+		return TLE
+	}
+	return FAILED
+}
+
+func displayStartupInfo(config Config, rounds int, maxWorkers int) {
+	tm.Printf("Running %v rounds with %v workers.\n", rounds, maxWorkers)
+	for i, exec := range config.Execs {
+		tm.Printf("%d. %s (%.2fs timeout)\n", i+1, exec.Name, exec.Timeout)
+	}
+	tm.Flush()
+}

--- a/same.go
+++ b/same.go
@@ -79,7 +79,7 @@ func runSameTests(config Config, rounds int, exec1, exec2 Exec) {
 		tm.Println()
 		tm.Flush()
 		// goterm does not seem to handle big strings? Use fmt instead.
-		fmt.Print(summarizer.Summary())
+		fmt.Print(summarizer.Summary(false))
 
 		monitorDone <- struct{}{}
 	}()
@@ -138,11 +138,12 @@ func runSameTest(index int, config Config, exec1, exec2 Exec, baseEvent Event, e
 	}
 
 	if err1 != nil || err2 != nil {
+		// This is a hack to ensure both execs have the same "SAME" count.
 		if err1 == nil {
-			events <- baseEvent.Exec(0).Status(SAME_OUT)
+			events <- baseEvent.Exec(0).Status(OK)
 		}
 		if err2 == nil {
-			events <- baseEvent.Exec(1).Status(SAME_OUT)
+			events <- baseEvent.Exec(1).Status(OK)
 		}
 		return
 	}
@@ -191,7 +192,8 @@ func determineStatus(err error) Status {
 func displayStartupInfo(config Config, rounds int, maxWorkers int) {
 	tm.Printf("Running %v rounds with %v workers.\n", rounds, maxWorkers)
 	for i, exec := range config.Execs {
-		tm.Printf("%d. %s (%.2fs timeout)\n", i+1, exec.Name, exec.Timeout)
+		tm.Printf("%d. %s\t(%.2fs timeout)\n", i+1, exec.Name, exec.Timeout)
 	}
+	tm.Println()
 	tm.Flush()
 }

--- a/summary.go
+++ b/summary.go
@@ -46,7 +46,7 @@ func (s *Summarizer) Ingest(event Event) {
 	}
 }
 
-func (s *Summarizer) Summary() string {
+func (s *Summarizer) Summary(isRun bool) string {
 	var summary strings.Builder
 
 	maxNameLen := 0
@@ -58,11 +58,14 @@ func (s *Summarizer) Summary() string {
 
 	for i, name := range s.names {
 		summary.WriteString(fmt.Sprintf("%d. %-*s", i+1, maxNameLen, name))
-		summary.WriteString(fmt.Sprintf("   OK %2d", s.counters[i][OK]))
-		summary.WriteString(fmt.Sprintf(" | WA %2d", s.counters[i][WA]))
-		if tle := s.counters[i][TLE]; tle > 0 {
-			summary.WriteString(fmt.Sprintf(" | TLE %2d", tle))
+		if isRun {
+			summary.WriteString(fmt.Sprintf("   OK %2d", s.counters[i][OK]))
+			summary.WriteString(fmt.Sprintf(" | WA %2d", s.counters[i][WA]))
+		} else {
+			summary.WriteString(fmt.Sprintf("   SAME %2d", s.counters[i][SAME_OUT]))
+			summary.WriteString(fmt.Sprintf(" | DIFF %2d", s.counters[i][MISMATCH]))
 		}
+		summary.WriteString(fmt.Sprintf(" | TLE %2d", s.counters[i][TLE]))
 		if failed := s.counters[i][FAILED]; failed > 0 {
 			summary.WriteString(fmt.Sprintf(" (%d failed)", failed))
 		}

--- a/ui.go
+++ b/ui.go
@@ -53,21 +53,27 @@ func (u *UI) Display(event Event) {
 
 func (u *UI) renderTestCell(execIndex, testIndex int, status Status) {
 	symbol := map[Status]string{
-		NONE:     "_",
-		STARTING: "?",
-		FAILED:   "⚠",
-		WA:       "✖",
-		TLE:      "⏱",
-		OK:       "✓",
+		NONE:       "_",
+		STARTING:   "?",
+		FAILED:     "⚠",
+		WA:         "✖",
+		TLE:        "⏱",
+		OK:         "✓",
+		GENERATING: ".",
+		SAME_OUT:   "✓",
+		MISMATCH:   "/",
 	}[status]
 
 	color := map[Status]int{
-		NONE:     tm.WHITE,
-		STARTING: tm.YELLOW,
-		FAILED:   tm.MAGENTA,
-		WA:       tm.RED,
-		TLE:      tm.BLUE,
-		OK:       tm.GREEN,
+		NONE:       tm.WHITE,
+		STARTING:   tm.YELLOW,
+		FAILED:     tm.MAGENTA,
+		WA:         tm.RED,
+		TLE:        tm.BLUE,
+		OK:         tm.GREEN,
+		GENERATING: tm.YELLOW,
+		SAME_OUT:   tm.GREEN,
+		MISMATCH:   tm.RED,
 	}[status]
 
 	rowOffset := len(u.names) - execIndex


### PR DESCRIPTION
This PR adds a new subcommand for checking if two programs have the same output on random tests.

This functionality should be heavily refactored in the future.